### PR TITLE
get_auditlogpath/get_auditdirpath/get_wflogpath return absolute paths

### DIFF
--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -40,31 +40,31 @@ class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
 
     def get_wflogpath(self):
         '''
-        Get the path to the workflow-speicfic log file.
+        Get the path to the workflow-specific log file.
         '''
         if self._wflogpath == '':
             self._ensure_timestamp()
             clsname = self.__class__.__name__.lower()
             logpath = 'log/workflow_' + clsname + '_started_{t}.log'.format(t=self._wfstart)
-            self._wflogpath = logpath
+            self._wflogpath = os.path.abspath(logpath)
         return self._wflogpath
 
     def get_auditdirpath(self):
         '''
-        Get the path to the workflow-speicfic audit trail directory.
+        Get the path to the workflow-specific audit trail directory.
         '''
         self._ensure_timestamp()
         clsname = self.__class__.__name__.lower()
-        audit_dirpath = 'audit/.audit_%s_%s' % (clsname, self._wfstart)
+        audit_dirpath = os.path.abspath('audit/.audit_%s_%s' % (clsname, self._wfstart))
         return audit_dirpath
 
     def get_auditlogpath(self):
         '''
-        Get the path to the workflow-speicfic audit trail file.
+        Get the path to the workflow-specific audit trail file.
         '''
         self._ensure_timestamp()
         clsname = self.__class__.__name__.lower()
-        audit_dirpath = 'audit/workflow_%s_started_%s.audit' % (clsname, self._wfstart)
+        audit_dirpath = os.path.abspath('audit/workflow_%s_started_%s.audit' % (clsname, self._wfstart))
         return audit_dirpath
 
     def add_auditinfo(self, infotype, infolog):


### PR DESCRIPTION
relative paths break logging if workflow changes working directory:
2017-12-19 14:50:43 |    ERROR | Error in event callback for 'event.core.processing_time'
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/luigi/task.py", line 155, in trigger_event
    callback(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/sciluigi/audit.py", line 76, in save_end_time
    self.add_auditinfo('task_exectime_sec', '%.3f' % task_exectime_sec)
  File "/usr/local/lib/python2.7/dist-packages/sciluigi/audit.py", line 26, in add_auditinfo
    return self._add_auditinfo(self.instance_name, infotype, infoval)
  File "/usr/local/lib/python2.7/dist-packages/sciluigi/audit.py", line 40, in _add_auditinfo
    with open(auditfile, 'w') as afile:
IOError: [Errno 2] No such file or directory: 'audit/.audit_XXXXXXXXXworkflow_20171219_145030_384056/XXXXXXXXXXXXXXXXXXXXXXXXXXXX'