### PR TITLE
Added casting to string of slurm_stderr and jobinfo_stdout

### DIFF
--- a/sciluigi/slurm.py
+++ b/sciluigi/slurm.py
@@ -191,14 +191,14 @@ class SlurmHelpers():
         salloc: Job allocation 5836263 has been revoked.
         '''
 
-        matches = re.search('[0-9]+', slurm_stderr)
+        matches = re.search('[0-9]+', str(slurm_stderr))
         if matches:
             jobid = matches.group(0)
 
             # Write slurm execution time to audit log
             cmd = 'sacct -j {jobid} --noheader --format=elapsed'.format(jobid=jobid)
             (_, jobinfo_stdout, _) = self.ex_local(cmd)
-            sacct_matches = re.findall('([0-9\:\-]+)', jobinfo_stdout)
+            sacct_matches = re.findall('([0-9\:\-]+)', str(jobinfo_stdout))
 
             if len(sacct_matches) < 2:
                 log.warn('Not enough matches from sacct for task %s: %s',


### PR DESCRIPTION
For compatibility with Python 3, where subprocess is returning bytes instead of string. This fix was discussed on this [issue](https://github.com/pharmbio/sciluigi/issues/47). I have tested this on a Slurm cluster with both a Python 3.6 environment and a Python 2.7 environment, so the casting with `str` seems to work. There is a possibility to specify the encoding, using `.decode('utf-8')` or similar. I don't know when/if this would be necessary. 