### PR TITLE
Remove dependencies on boto3 and psycopg2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,6 @@ setup(
     ],
     install_requires=[
         'luigi',
-        'psycopg2',
-        'boto3'
         ],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
In `setup.py`, there are dependencies on `boto3` and `psycopg2` (i.e. the AWS SDK for Python and the PostgreSQL database adaptor). I don't see any references to these anywhere in the code, so I think these can be safely removed. Is that accurate?

There are a couple of test failures, but those seem to be due to `luigi.six` being removed in the v3 release.