### PR TITLE
Pin Luigi package version to below v3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         'sciluigi',
     ],
     install_requires=[
-        'luigi',
+        'luigi>=1.3.0,<3',
         'psycopg2',
         'boto3'
         ],


### PR DESCRIPTION
README.md states that Luigi versions 1.3.x-2.0.1 are supported, but setup.py only has install_requires luigi, so the latest (v3) package is installed instead. This change captures the requirement, so that if a user installs the package, the latest 2.x release is used instead.