### PR TITLE
Remove 'six' usage

### DIFF
--- a/sciluigi/audit.py
+++ b/sciluigi/audit.py
@@ -7,7 +7,6 @@ import luigi
 import os
 import random
 import time
-from luigi.six import iteritems
 
 # ==============================================================================
 
@@ -74,6 +73,6 @@ class AuditTrailHelpers(object):
                 proctime=task_exectime_sec)
             log.info(msg)
             self.add_auditinfo('task_exectime_sec', '%.3f' % task_exectime_sec)
-            for paramname, paramval in iteritems(self.param_kwargs):
+            for paramname, paramval in self.param_kwargs.items():
                 if paramname not in ['workflow_task']:
                     self.add_auditinfo(paramname, paramval)

--- a/sciluigi/dependencies.py
+++ b/sciluigi/dependencies.py
@@ -7,7 +7,6 @@ import luigi
 import warnings
 from luigi.contrib.postgres import PostgresTarget
 from luigi.contrib.s3 import S3Target
-from luigi.six import iteritems
 
 # ==============================================================================
 
@@ -78,7 +77,7 @@ class DependencyHelpers(object):
         for use in luigi's requires() method.
         '''
         upstream_tasks = set()
-        for attrname, attrval in iteritems(self.__dict__):
+        for attrname, attrval in self.__dict__.items():
             if attrname.startswith('in_'):
                 upstream_tasks = self._add_upstream_tasks(upstream_tasks, attrval)
 
@@ -98,7 +97,7 @@ class DependencyHelpers(object):
             for new_task in new_tasks:
                 tasks = self._add_upstream_tasks(tasks, new_task)
         elif isinstance(new_tasks, dict):
-            for _, new_task in iteritems(new_tasks):
+            for _, new_task in new_tasks.items():
                 tasks = self._add_upstream_tasks(tasks, new_task)
         else:
             raise Exception('Input value is neither callable, TargetInfo, nor list: %s' % val)
@@ -150,7 +149,7 @@ class DependencyHelpers(object):
             for valitem in val:
                 targets = self._parse_outputitem(valitem, targets)
         elif isinstance(val, dict):
-            for _, valitem in iteritems(val):
+            for _, valitem in val.items():
                 targets = self._parse_outputitem(valitem, targets)
         else:
             raise Exception('Input item is neither callable, TargetInfo, nor list: %s' % val)

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -3,7 +3,6 @@ This module contains sciluigi's subclasses of luigi's Task class.
 '''
 import json
 import luigi
-from luigi.six import iteritems, string_types
 import logging
 import subprocess as sub
 import warnings
@@ -22,15 +21,15 @@ def new_task(name, cls, workflow_task, **kwargs):
     (use WorkflowTask.new_task() instead).
     '''
     slurminfo = None
-    for key, val in [(key, val) for key, val in iteritems(kwargs)]:
+    for key, val in [(key, val) for key, val in kwargs.items()]:
         # Handle non-string keys
-        if not isinstance(key, string_types):
+        if not isinstance(key, str):
             raise Exception("Key in kwargs to new_task is not string. Must be string: %s" % key)
         # Handle non-string values
         if isinstance(val, sciluigi.slurm.SlurmInfo):
             slurminfo = val
             kwargs[key] = val
-        elif not isinstance(val, string_types):
+        elif not isinstance(val, str):
             try:
                 kwargs[key] = json.dumps(val) # Force conversion into string
             except TypeError:

--- a/sciluigi/util.py
+++ b/sciluigi/util.py
@@ -6,7 +6,6 @@ sciluigi library
 import csv
 import os
 import time
-from luigi.six import iteritems
 
 def timestamp(datefmt='%Y-%m-%d, %H:%M:%S'):
     '''
@@ -51,6 +50,6 @@ def dict_to_recordfile(filehandle, records):
     '''
     csvwt = csv.writer(filehandle, delimiter=RECORDFILE_DELIMITER, skipinitialspace=True)
     rows = []
-    for key, val in iteritems(records):
+    for key, val in records.items():
         rows.append([key, val])
     csvwt.writerows(rows)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open('README.rst') as fobj:
 
 setup(
     name='sciluigi',
-    version='0.9.7',
+    version='0.1.0',
     description='Helper library for writing dynamic, flexible workflows in luigi',
     long_description=long_description,
     author='Samuel Lampa',
@@ -42,9 +42,7 @@ setup(
         'Natural Language :: English',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.7',
         'Topic :: Scientific/Engineering',
         'Topic :: Scientific/Engineering :: Bio-Informatics',


### PR DESCRIPTION
Addresses #66.

The newest version of luigi has dropped `six` which leads to errors if we want to use sciluigi. I went ahead and removed `six` usages from sciluigi and bumped the version to 0.1.0 to indicate major changes i.e. drop of Python 2 support. 

Might be too radical, but I thought I try to get it merged :) 